### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/component_wtest.mbt
+++ b/src/component_wtest.mbt
@@ -4,7 +4,7 @@ test (t : @test.T) {
     text : String
     html : Lazy[String]
   }
-  type Component LazyRec[ComponentRepr]
+  struct Component(LazyRec[ComponentRepr])
   fn new() -> Component {
     LazyRec::new(fn(self : Lazy[ComponentRepr]) {
       {
@@ -19,23 +19,23 @@ test (t : @test.T) {
   }
 
   fn modify_text(self : Component, f : (String) -> String) -> Unit {
-    self._.modify(fn(self) { { text: f(self.text), html: self.html } })
+    self.inner().modify(fn(self) { { text: f(self.text), html: self.html } })
   }
 
   fn html(self : Component) -> String {
-    self._.get(fn(self) { self.html.force() })
+    self.inner().get(fn(self) { self.html.force() })
   }
 
   let c = new()
   modify_text(c, fn(_) { "hello world" })
-  inspect!(html(c), content="<div>hello world<div/>")
-  inspect!(html(c), content="<div>hello world<div/>")
-  inspect!(html(c), content="<div>hello world<div/>")
-  inspect!(html(c), content="<div>hello world<div/>")
+  inspect(html(c), content="<div>hello world<div/>")
+  inspect(html(c), content="<div>hello world<div/>")
+  inspect(html(c), content="<div>hello world<div/>")
+  inspect(html(c), content="<div>hello world<div/>")
   modify_text(c, fn(x) { x + "!" })
-  inspect!(html(c), content="<div>hello world!<div/>")
-  inspect!(html(c), content="<div>hello world!<div/>")
-  inspect!(html(c), content="<div>hello world!<div/>")
-  inspect!(html(c), content="<div>hello world!<div/>")
-  t.snapshot!(filename="component.txt")
+  inspect(html(c), content="<div>hello world!<div/>")
+  inspect(html(c), content="<div>hello world!<div/>")
+  inspect(html(c), content="<div>hello world!<div/>")
+  inspect(html(c), content="<div>hello world!<div/>")
+  t.snapshot(filename="component.txt")
 }

--- a/src/extensible_parser_wtest.mbt
+++ b/src/extensible_parser_wtest.mbt
@@ -148,7 +148,7 @@ fn[Repr : AST + Var] extendedParser() -> LazyBuilder[ExtendedParser[Repr]] {
   }
 
   let originalParser : LazyBuilder[OriginalParser[Repr]] = originalParser()
-  originalParser.inherit(f, g)
+  originalParser.inherits(f, g)
 }
 
 ///|

--- a/src/extensible_parser_wtest.mbt
+++ b/src/extensible_parser_wtest.mbt
@@ -1,8 +1,8 @@
 ///|
-typealias Seq[A] = @pc.Seq[A]
+typealias @pc.Seq
 
 ///|
-typealias Parser[A] = @pc.Parser[Char, A]
+typealias @pc.Parser[Char, A] as Parser[A]
 
 ///|
 priv struct OriginalParser[Repr] {
@@ -52,10 +52,10 @@ let charP = @pc.pchar
 let spaces : @pc.Parser[Char, Array[Char]] = @pc.pchar(' ').repeat()
 
 ///|
-fn between[A, B, C](
+fn[A, B, C] between(
   content : Parser[A],
   left~ : Parser[B],
-  right~ : Parser[C]
+  right~ : Parser[C],
 ) -> Parser[A] {
   left.and_then(content).omit_first().and_then(right).omit_second()
 }
@@ -72,11 +72,11 @@ priv trait Var {
 }
 
 ///|
-priv type MyString String
+priv struct MyString(String)
 
 ///|
 impl Show for MyString with output(self, logger) {
-  self._.output(logger)
+  self.inner().output(logger)
 }
 
 ///|
@@ -95,7 +95,7 @@ impl Var for MyString with var(self) {
 }
 
 ///|
-fn originalParser[Repr : AST]() -> LazyBuilder[OriginalParser[Repr]] {
+fn[Repr : AST] originalParser() -> LazyBuilder[OriginalParser[Repr]] {
   fn(self) {
     Lazy::from_fun(fn() {
       let litP = Lazy::from_val(intP.map(Repr::lit))
@@ -133,7 +133,7 @@ fn originalParser[Repr : AST]() -> LazyBuilder[OriginalParser[Repr]] {
 }
 
 ///|
-fn extendedParser[Repr : AST + Var]() -> LazyBuilder[ExtendedParser[Repr]] {
+fn[Repr : AST + Var] extendedParser() -> LazyBuilder[ExtendedParser[Repr]] {
   fn f(self : OriginalParser[Repr]) -> ExtendedParser[Repr] {
     let { litP, plusP, wholeP } = self
     let varP = stringP.map(Repr::var)
@@ -158,23 +158,23 @@ test "OriginalParser" {
   let litP = litP.force()
   let plusP = plusP.force()
   let wholeP = wholeP.force()
-  inspect!(
+  inspect(
     litP.parse(Seq::from_string("123")),
-    content=
+    content=(
       #|Some(("123", ))
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     plusP.parse(Seq::from_string("(1 + 2)")),
-    content=
+    content=(
       #|Some(("1 + 2", ))
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     wholeP.parse(Seq::from_string("(1 + 2)")),
-    content=
+    content=(
       #|Some(("1 + 2", ))
-    ,
+    ),
   )
 }
 
@@ -187,22 +187,22 @@ test "ExtendedParser" {
   let plusP = plusP.force()
   let wholeP = wholeP.force()
   let varP = varP.force()
-  inspect!(
+  inspect(
     wholeP.parse(Seq::from_string("(1 + a)")),
-    content=
+    content=(
       #|Some(("1 + a", ))
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     varP.parse(Seq::from_string("abc")),
-    content=
+    content=(
       #|Some(("abc", ))
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     wholeP.parse(Seq::from_string("(1 + (1 + 2))")),
-    content=
+    content=(
       #|Some(("1 + 1 + 2", ))
-    ,
+    ),
   )
 }

--- a/src/lazy.mbt
+++ b/src/lazy.mbt
@@ -1,5 +1,5 @@
 ///|
-pub fn Lazy::force[A](self : Lazy[A]) -> A {
+pub fn[A] Lazy::force(self : Lazy[A]) -> A {
   match self.repr {
     Value(val) => val
     Thunk(fun) => {
@@ -11,22 +11,22 @@ pub fn Lazy::force[A](self : Lazy[A]) -> A {
 }
 
 ///|
-fn Lazy::from_val[A](val : A) -> Lazy[A] {
+fn[A] Lazy::from_val(val : A) -> Lazy[A] {
   { repr: Value(val) }
 }
 
 ///|
-fn Lazy::from_fun[A](fun : () -> A) -> Lazy[A] {
+fn[A] Lazy::from_fun(fun : () -> A) -> Lazy[A] {
   { repr: Thunk(fun) }
 }
 
 ///|
-pub fn Lazy::new[A](fun : () -> A) -> Lazy[A] {
+pub fn[A] Lazy::new(fun : () -> A) -> Lazy[A] {
   Lazy::from_fun(fun)
 }
 
 ///|
-pub fn Lazy::map[A, B](self : Lazy[A], f : (A) -> B) -> Lazy[B] {
+pub fn[A, B] Lazy::map(self : Lazy[A], f : (A) -> B) -> Lazy[B] {
   match self.repr {
     Value(val) => Lazy::from_val(f(val))
     Thunk(fun) =>
@@ -39,7 +39,7 @@ pub fn Lazy::map[A, B](self : Lazy[A], f : (A) -> B) -> Lazy[B] {
 }
 
 ///|
-pub fn Lazy::fix[A](f : (Lazy[A]) -> Lazy[A]) -> Lazy[A] {
+pub fn[A] Lazy::fix(f : (Lazy[A]) -> Lazy[A]) -> Lazy[A] {
   fn fun() -> A {
     f(Lazy::from_fun(fun)).force()
   }
@@ -48,7 +48,7 @@ pub fn Lazy::fix[A](f : (Lazy[A]) -> Lazy[A]) -> Lazy[A] {
 }
 
 ///|
-pub fn Lazy::join[A](self : Lazy[Lazy[A]]) -> Lazy[A] {
+pub fn[A] Lazy::join(self : Lazy[Lazy[A]]) -> Lazy[A] {
   match self.repr {
     Value(val) => val
     Thunk(fun) => fun()
@@ -56,7 +56,7 @@ pub fn Lazy::join[A](self : Lazy[Lazy[A]]) -> Lazy[A] {
 }
 
 ///|
-pub fn Lazy::bind[A, B](self : Lazy[A], f : (A) -> Lazy[B]) -> Lazy[B] {
+pub fn[A, B] Lazy::bind(self : Lazy[A], f : (A) -> Lazy[B]) -> Lazy[B] {
   match self.repr {
     Value(val) => f(val)
     Thunk(fun) => f(fun())

--- a/src/lazy.mbti
+++ b/src/lazy.mbti
@@ -16,7 +16,7 @@ impl[A : Show] Show for Lazy[A]
 
 type LazyBuilder[A]
 impl LazyBuilder {
-  inherit[A, B](Self[A], (A) -> B, (B) -> A) -> Self[B]
+  inherits[A, B](Self[A], (A) -> B, (B) -> A) -> Self[B]
   map[A](Self[A], (A) -> A) -> Self[A]
   new[A]((Lazy[A]) -> A) -> Self[A]
   run[A](Self[A]) -> Lazy[A]

--- a/src/lazy_wtest.mbt
+++ b/src/lazy_wtest.mbt
@@ -1,5 +1,5 @@
 ///|
 test "fix/const" {
   let x = Lazy::fix(fn(_) { Lazy::from_val(0) }).force()
-  inspect!(x, content="0")
+  inspect(x, content="0")
 }

--- a/src/lazybuilder.mbt
+++ b/src/lazybuilder.mbt
@@ -9,7 +9,7 @@ pub fn[A] LazyBuilder::run(self : LazyBuilder[A]) -> Lazy[A] {
 }
 
 ///|
-pub fn[A, B] LazyBuilder::inherit(
+pub fn[A, B] LazyBuilder::inherits(
   self : LazyBuilder[A],
   f : (A) -> B,
   g : (B) -> A,

--- a/src/lazybuilder.mbt
+++ b/src/lazybuilder.mbt
@@ -1,35 +1,35 @@
 ///|
-pub fn LazyBuilder::run_force[A](self : LazyBuilder[A]) -> A {
+pub fn[A] LazyBuilder::run_force(self : LazyBuilder[A]) -> A {
   self.run().force()
 }
 
 ///|
-pub fn LazyBuilder::run[A](self : LazyBuilder[A]) -> Lazy[A] {
-  Lazy::fix(self._)
+pub fn[A] LazyBuilder::run(self : LazyBuilder[A]) -> Lazy[A] {
+  Lazy::fix(self.inner())
 }
 
 ///|
-pub fn LazyBuilder::inherit[A, B](
+pub fn[A, B] LazyBuilder::inherit(
   self : LazyBuilder[A],
   f : (A) -> B,
-  g : (B) -> A
+  g : (B) -> A,
 ) -> LazyBuilder[B] {
   let ab = fn(a : Lazy[A]) { a.map(f) }
   let ba = fn(b : Lazy[B]) { b.map(g) }
-  let aa = self._
+  let aa = self.inner()
   @fun.compose(ab, @fun.compose(aa, ba))
 }
 
 ///|
-pub fn LazyBuilder::map[A](
+pub fn[A] LazyBuilder::map(
   self : LazyBuilder[A],
-  f : (A) -> A
+  f : (A) -> A,
 ) -> LazyBuilder[A] {
   let aa = fn(a : Lazy[A]) { a.map(f) }
-  @fun.compose(aa, self._)
+  @fun.compose(aa, self.inner())
 }
 
 ///|
-pub fn LazyBuilder::new[A](f : (Lazy[A]) -> A) -> LazyBuilder[A] {
+pub fn[A] LazyBuilder::new(f : (Lazy[A]) -> A) -> LazyBuilder[A] {
   fn(self : Lazy[A]) { Lazy::from_val(f(self)) }
 }

--- a/src/lazybuilder_wtest.mbt
+++ b/src/lazybuilder_wtest.mbt
@@ -11,7 +11,7 @@ test "fix/rec" {
   })
   x.run_force() |> ignore
   let x = x.run_force()
-  inspect!(x.1.force(), content="4")
+  inspect(x.1.force(), content="4")
 }
 
 ///|
@@ -38,15 +38,15 @@ test "fix/even odd" {
       }),
     }
   })
-  let x = nat._ |> Lazy::fix
+  let x = nat.inner() |> Lazy::fix
   let nat = nat.run_force()
   let even = nat.even.force()
   let odd = nat.odd.force()
-  inspect!(
+  inspect(
     Int::until(0, 5).map(even),
     content="[true, false, true, false, true]",
   )
-  inspect!(
+  inspect(
     Int::until(0, 5).map(odd),
     content="[false, true, false, true, false]",
   )
@@ -72,53 +72,53 @@ test "memo test" (t : @test.T) {
   })
   let x = x.run_force()
   let y = y.run_force()
-  inspect!(
+  inspect(
     x,
-    content=
+    content=(
       #|{source: 16, target: "10"}
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     x,
-    content=
+    content=(
       #|{source: 16, target: "10"}
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     x,
-    content=
+    content=(
       #|{source: 16, target: "10"}
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     x,
-    content=
+    content=(
       #|{source: 16, target: "10"}
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     y,
-    content=
+    content=(
       #|{source: 256, target: "100"}
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     y,
-    content=
+    content=(
       #|{source: 256, target: "100"}
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     y,
-    content=
+    content=(
       #|{source: 256, target: "100"}
-    ,
+    ),
   )
-  inspect!(
+  inspect(
     y,
-    content=
+    content=(
       #|{source: 256, target: "100"}
-    ,
+    ),
   )
-  t.snapshot!(filename="memo_test.txt")
+  t.snapshot(filename="memo_test.txt")
 }

--- a/src/lazybuilder_wtest.mbt
+++ b/src/lazybuilder_wtest.mbt
@@ -38,7 +38,7 @@ test "fix/even odd" {
       }),
     }
   })
-  let x = nat.inner() |> Lazy::fix
+  let _ = nat.inner() |> Lazy::fix
   let nat = nat.run_force()
   let even = nat.even.force()
   let odd = nat.odd.force()

--- a/src/lazylist_wtest.mbt
+++ b/src/lazylist_wtest.mbt
@@ -56,13 +56,13 @@ fn[A] List::take(self : List[A], n : Int) -> List[A] {
 }
 
 ///|
-fn[A] List::nth(self : List[A], n : Int) -> A {
+fn[A] List::_nth(self : List[A], n : Int) -> A {
   let mut n = n
   let mut res = None
   loop self {
     Nil => ()
     Cons(x, _) if n == 0 => res = Some(x)
-    Cons(x, xs) => {
+    Cons(_, xs) => {
       n -= 1
       continue xs.force()
     }
@@ -74,7 +74,7 @@ fn[A] List::nth(self : List[A], n : Int) -> A {
 fn[A] List::tail(self : List[A]) -> List[A] {
   match self {
     Nil => Nil
-    Cons(x, xs) => xs.force()
+    Cons(_, xs) => xs.force()
   }
 }
 

--- a/src/lazylist_wtest.mbt
+++ b/src/lazylist_wtest.mbt
@@ -8,7 +8,7 @@ priv enum List[A] {
 let counter : Ref[Int] = Ref::new(0)
 
 ///|
-fn List::reverse_append[A](self : List[A], other : List[A]) -> List[A] {
+fn[A] List::reverse_append(self : List[A], other : List[A]) -> List[A] {
   let mut acc = other
   loop self {
     Nil => ()
@@ -21,15 +21,15 @@ fn List::reverse_append[A](self : List[A], other : List[A]) -> List[A] {
 }
 
 ///|
-fn List::reverse[A](self : List[A]) -> List[A] {
+fn[A] List::reverse(self : List[A]) -> List[A] {
   self.reverse_append(Nil)
 }
 
 ///|
-fn List::zipWith[A, B, C](
+fn[A, B, C] List::zipWith(
   self : List[A],
   other : List[B],
-  f : (A, B) -> C
+  f : (A, B) -> C,
 ) -> List[C] {
   match (self, other) {
     (Nil, _) => Nil
@@ -40,7 +40,7 @@ fn List::zipWith[A, B, C](
 }
 
 ///|
-fn List::take[A](self : List[A], n : Int) -> List[A] {
+fn[A] List::take(self : List[A], n : Int) -> List[A] {
   let mut acc = Nil
   let mut n = n
   loop self {
@@ -56,7 +56,7 @@ fn List::take[A](self : List[A], n : Int) -> List[A] {
 }
 
 ///|
-fn List::nth[A](self : List[A], n : Int) -> A {
+fn[A] List::nth(self : List[A], n : Int) -> A {
   let mut n = n
   let mut res = None
   loop self {
@@ -71,7 +71,7 @@ fn List::nth[A](self : List[A], n : Int) -> A {
 }
 
 ///|
-fn List::tail[A](self : List[A]) -> List[A] {
+fn[A] List::tail(self : List[A]) -> List[A] {
   match self {
     Nil => Nil
     Cons(x, xs) => xs.force()
@@ -114,18 +114,18 @@ test {
     )
   })
   let fibs = fibs_rec.get(fn(x) { x })
-  inspect!(
+  inspect(
     fibs.take(20),
     content="[0,1,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584,4181,]",
   )
-  inspect!(
+  inspect(
     fibs.take(20),
     content="[0,1,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584,4181,]",
   )
   let fibs = fibs_rec.get(fn(x) { x })
-  inspect!(
+  inspect(
     fibs.take(20),
     content="[0,1,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584,4181,]",
   )
-  inspect!(counter, content="{val: 19}")
+  inspect(counter, content="{val: 19}")
 }

--- a/src/lazyrec.mbt
+++ b/src/lazyrec.mbt
@@ -1,16 +1,16 @@
 ///|
-pub fn LazyRec::new[A](f : (Lazy[A]) -> A) -> LazyRec[A] {
+pub fn[A] LazyRec::new(f : (Lazy[A]) -> A) -> LazyRec[A] {
   { repr: LazyBuilder::new(f), memo: None }
 }
 
 ///|
-pub fn LazyRec::modify[A](self : LazyRec[A], f : (A) -> A) -> Unit {
+pub fn[A] LazyRec::modify(self : LazyRec[A], f : (A) -> A) -> Unit {
   self.repr = self.repr.map(f)
   self.memo = None
 }
 
 ///|
-pub fn LazyRec::get[A, B](self : LazyRec[A], f : (A) -> B) -> B {
+pub fn[A, B] LazyRec::get(self : LazyRec[A], f : (A) -> B) -> B {
   fn aux(lazy) {
     self.memo = Some(lazy)
     lazy.force() |> f
@@ -23,7 +23,7 @@ pub fn LazyRec::get[A, B](self : LazyRec[A], f : (A) -> B) -> B {
 }
 
 ///|
-pub fn LazyRec::force[A](self : LazyRec[A]) -> A {
+pub fn[A] LazyRec::force(self : LazyRec[A]) -> A {
   match self.memo {
     None => {
       let lazy = self.repr.run()

--- a/src/lazyrec.mbt
+++ b/src/lazyrec.mbt
@@ -11,14 +11,14 @@ pub fn[A] LazyRec::modify(self : LazyRec[A], f : (A) -> A) -> Unit {
 
 ///|
 pub fn[A, B] LazyRec::get(self : LazyRec[A], f : (A) -> B) -> B {
-  fn aux(lazy) {
-    self.memo = Some(lazy)
-    lazy.force() |> f
+  fn aux(lz) {
+    self.memo = Some(lz)
+    lz.force() |> f
   }
 
   match self.memo {
     None => aux(self.repr.run())
-    Some(lazy) => aux(lazy)
+    Some(lz) => aux(lz)
   }
 }
 
@@ -26,11 +26,11 @@ pub fn[A, B] LazyRec::get(self : LazyRec[A], f : (A) -> B) -> B {
 pub fn[A] LazyRec::force(self : LazyRec[A]) -> A {
   match self.memo {
     None => {
-      let lazy = self.repr.run()
-      self.memo = Some(lazy)
-      lazy.force()
+      let lz = self.repr.run()
+      self.memo = Some(lz)
+      lz.force()
     }
-    Some(lazy) => lazy.force()
+    Some(lz) => lz.force()
   }
 }
 

--- a/src/moon.pkg.json
+++ b/src/moon.pkg.json
@@ -1,5 +1,4 @@
 {
-  "warn-list": "-1-2-3-5-6-7-8",
   "import": [
     "illusory0x0/fun",
     {

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -10,7 +10,7 @@ struct Lazy[A] {
 }
 
 ///|
-type LazyBuilder[A] (Lazy[A]) -> Lazy[A]
+struct LazyBuilder[A]((Lazy[A]) -> Lazy[A])
 
 ///|
 struct LazyRec[A] {


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Replace reserved word 'inherit' with 'inherits' in LazyBuilder
- Replace reserved word 'lazy' with 'lz' in LazyRec functions
- Fix unused variable warnings by using wildcard patterns
- Mark unused function with underscore prefix
- Remove all warning suppressions from warn-list
- Update interface file to reflect API changes

This commit addresses warnings 0001 (unused function), 0002 (unused variables), 
and 0035 (reserved words) that were previously suppressed in the configuration.

All local compiler warnings are now resolved, improving code quality and 
maintainability.