### PR TITLE
Fix warnings in test files with minimal changes

### DIFF
--- a/src/component_wtest.mbt
+++ b/src/component_wtest.mbt
@@ -1,5 +1,5 @@
 ///|
-test (t : @test.T) {
+test (t : @test.Test) {
   struct ComponentRepr {
     text : String
     html : Lazy[String]
@@ -19,11 +19,11 @@ test (t : @test.T) {
   }
 
   fn modify_text(self : Component, f : (String) -> String) -> Unit {
-    self.inner().modify(fn(self) { { text: f(self.text), html: self.html } })
+    self.0.modify(fn(self) { { text: f(self.text), html: self.html } })
   }
 
   fn html(self : Component) -> String {
-    self.inner().get(fn(self) { self.html.force() })
+    self.0.get(fn(self) { self.html.force() })
   }
 
   let c = new()

--- a/src/extensible_parser_wtest.mbt
+++ b/src/extensible_parser_wtest.mbt
@@ -1,5 +1,5 @@
 ///|
-typealias @pc.Parser
+using @pc {type Parser}
 
 ///|
 priv struct OriginalParser[Repr] {
@@ -60,7 +60,7 @@ priv struct MyString(String)
 
 ///|
 impl Show for MyString with output(self, logger) {
-  self.inner().output(logger)
+  self.0.output(logger)
 }
 
 ///|
@@ -70,7 +70,7 @@ impl AST for MyString with lit(self) {
 
 ///|
 impl AST for MyString with plus(lhs, rhs) {
-  "(\{lhs.inner()} + \{rhs.inner()})"
+  "(\{lhs.0} + \{rhs.0})"
 }
 
 ///|

--- a/src/lazybuilder.mbt
+++ b/src/lazybuilder.mbt
@@ -5,11 +5,11 @@ pub fn[A] LazyBuilder::run_force(self : LazyBuilder[A]) -> A {
 
 ///|
 pub fn[A] LazyBuilder::run(self : LazyBuilder[A]) -> Lazy[A] {
-  Lazy::fix(self.inner())
+  Lazy::fix(self.0)
 }
 
 ///|
-typealias (A) -> B as Arrow[A, B]
+type Arrow[A, B] = (A) -> B
 
 ///|
 fn[A, B, C] compose(f : Arrow[B, C], g : Arrow[A, B]) -> Arrow[A, C] {
@@ -24,7 +24,7 @@ pub fn[A, B] LazyBuilder::inherit_(
 ) -> LazyBuilder[B] {
   let ab = fn(a : Lazy[A]) { a.map(f) }
   let ba = fn(b : Lazy[B]) { b.map(g) }
-  let aa = self.inner()
+  let aa = self.0
   compose(ab, compose(aa, ba))
 }
 
@@ -34,7 +34,7 @@ pub fn[A] LazyBuilder::map(
   f : (A) -> A,
 ) -> LazyBuilder[A] {
   let aa = fn(a : Lazy[A]) { a.map(f) }
-  compose(aa, self.inner())
+  compose(aa, self.0)
 }
 
 ///|

--- a/src/lazybuilder_wtest.mbt
+++ b/src/lazybuilder_wtest.mbt
@@ -38,7 +38,7 @@ test "fix/even odd" {
       }),
     }
   })
-  let x = nat.inner() |> Lazy::fix
+  let x = nat.0 |> Lazy::fix
   let nat = nat.run_force()
   let even = nat.even.force()
   let odd = nat.odd.force()
@@ -53,7 +53,7 @@ test "fix/even odd" {
 }
 
 ///|
-test "memo test" (t : @test.T) {
+test "memo test" (t : @test.Test) {
   struct X {
     source : Int
     target : Lazy[String]

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -7,31 +7,27 @@ package "illusory0x0/lazy"
 
 // Types and methods
 type Lazy[A]
-fn[A, B] Lazy::bind(Self[A], (A) -> Self[B]) -> Self[B]
-fn[A] Lazy::fix((Self[A]) -> Self[A]) -> Self[A]
-fn[A] Lazy::force(Self[A]) -> A
-fn[A] Lazy::join(Self[Self[A]]) -> Self[A]
-fn[A, B] Lazy::map(Self[A], (A) -> B) -> Self[B]
-fn[A] Lazy::new(() -> A) -> Self[A]
-fn[A : Show] Lazy::output(Self[A], &Logger) -> Unit // from trait `Show`
-fn[A : Show] Lazy::to_string(Self[A]) -> String // from trait `Show`
-impl[A : Show] Show for Lazy[A]
+pub fn[A, B] Lazy::bind(Self[A], (A) -> Self[B]) -> Self[B]
+pub fn[A] Lazy::fix((Self[A]) -> Self[A]) -> Self[A]
+pub fn[A] Lazy::force(Self[A]) -> A
+pub fn[A] Lazy::join(Self[Self[A]]) -> Self[A]
+pub fn[A, B] Lazy::map(Self[A], (A) -> B) -> Self[B]
+pub fn[A] Lazy::new(() -> A) -> Self[A]
+pub impl[A : Show] Show for Lazy[A]
 
 type LazyBuilder[A]
-fn[A, B] LazyBuilder::inherit_(Self[A], (A) -> B, (B) -> A) -> Self[B]
-fn[A] LazyBuilder::map(Self[A], (A) -> A) -> Self[A]
-fn[A] LazyBuilder::new((Lazy[A]) -> A) -> Self[A]
-fn[A] LazyBuilder::run(Self[A]) -> Lazy[A]
-fn[A] LazyBuilder::run_force(Self[A]) -> A
+pub fn[A, B] LazyBuilder::inherit_(Self[A], (A) -> B, (B) -> A) -> Self[B]
+pub fn[A] LazyBuilder::map(Self[A], (A) -> A) -> Self[A]
+pub fn[A] LazyBuilder::new((Lazy[A]) -> A) -> Self[A]
+pub fn[A] LazyBuilder::run(Self[A]) -> Lazy[A]
+pub fn[A] LazyBuilder::run_force(Self[A]) -> A
 
 type LazyRec[A]
-fn[A] LazyRec::force(Self[A]) -> A
-fn[A, B] LazyRec::get(Self[A], (A) -> B) -> B
-fn[A] LazyRec::modify(Self[A], (A) -> A) -> Unit
-fn[A] LazyRec::new((Lazy[A]) -> A) -> Self[A]
-fn[T : Show] LazyRec::output(Self[T], &Logger) -> Unit // from trait `Show`
-fn[T : Show] LazyRec::to_string(Self[T]) -> String // from trait `Show`
-impl[T : Show] Show for LazyRec[T]
+pub fn[A] LazyRec::force(Self[A]) -> A
+pub fn[A, B] LazyRec::get(Self[A], (A) -> B) -> B
+pub fn[A] LazyRec::modify(Self[A], (A) -> A) -> Unit
+pub fn[A] LazyRec::new((Lazy[A]) -> A) -> Self[A]
+pub impl[T : Show] Show for LazyRec[T]
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

Fixed various warnings across test files and package metadata while maintaining functionality. The changes ensure `moon check` passes without errors and aim to preserve `moon test` compatibility.

## Changes

- **Test files**: Updated warning-related code in `src/component_wtest.mbt`, `src/extensible_parser_wtest.mbt`, and `src/lazybuilder_wtest.mbt`
- **Core implementation**: Minor adjustments in `src/lazybuilder.mbt` to address warnings
- **Package metadata**: Regenerated `src/pkg.generated.mbti` with updated type information

## Implementation Details

All changes were made with minimal modifications to preserve existing functionality:
- Only warning-related code was modified
- No changes to core package logic or public APIs
- Type information updates reflect the warning fixes

## Verification

The primary goal is to ensure `moon check` works without warnings. If `moon test` continues to pass, the package functionality remains intact. If the package didn't require fixes, no changes would have been made.